### PR TITLE
Add inherited venue parameter to run_and_format

### DIFF
--- a/R/misc.R
+++ b/R/misc.R
@@ -733,6 +733,7 @@ add_class <- function(x, class_to_add = "exp") {
 #' of code and output that is not self-contained, e.g., for teaching materials.
 #' 
 #' @param code The code to run - can be NULL, then the code is retrieved from the clipboard.
+#' @param venue The output venue for formatting. Defaults to "gh" (GitHub). Other options depend on reprex package support.
 #' @examples 
 #' if (interactive()) {
 #'   name <- "Lukas"
@@ -741,7 +742,7 @@ add_class <- function(x, class_to_add = "exp") {
 #' @export
 
 
-run_and_format <- function (code = NULL) {
+run_and_format <- function (code = NULL, venue = "gh") {
   
   .check_req_packages("reprex")
   
@@ -752,7 +753,7 @@ run_and_format <- function (code = NULL) {
     x_expr = substitute(code),
     input = NULL,
     wd = NULL,
-    venue = "gh",
+    venue = venue,
     
     render = TRUE,
     new_session = FALSE,

--- a/R/misc.R
+++ b/R/misc.R
@@ -730,10 +730,10 @@ add_class <- function(x, class_to_add = "exp") {
 #' run it and copy the formatted code and output to the clipboard. Note that 
 #' this does NOT run in a clean session and is thus unlikely to create *reproducible*
 #' examples. Instead, it is intended to be used to quickly get a formatted bit 
-#' of code and output that is not self-contained, e.g., for teaching materials.
+#' of code and output that is *not* self-contained, e.g., for teaching materials.
 #' 
 #' @param code The code to run - can be NULL, then the code is retrieved from the clipboard.
-#' @param venue The output venue for formatting. Defaults to "gh" (GitHub). Other options depend on reprex package support.
+#' @inheritParams reprex::reprex                                    
 #' @examples 
 #' if (interactive()) {
 #'   name <- "Lukas"


### PR DESCRIPTION
Add inherited venue parameter to run_and_format function

- Add venue parameter with default value "gh" to maintain backward compatibility
- Update internal reprex_internal call to use the venue parameter instead of hardcoded value
- Add documentation for the new venue parameter

Fixes #22

Generated with [Claude Code](https://claude.ai/code)